### PR TITLE
chore: cleaning up general linting errors and warnings

### DIFF
--- a/src/components/__tests__/popup.test.tsx
+++ b/src/components/__tests__/popup.test.tsx
@@ -3,7 +3,7 @@ import {
   render,
   RenderResult,
   waitFor,
-  fireEvent
+  fireEvent,
 } from '@testing-library/react';
 import { act } from 'react-dom/test-utils';
 

--- a/src/components/__tests__/popup.test.tsx
+++ b/src/components/__tests__/popup.test.tsx
@@ -1,5 +1,10 @@
 import React from 'react';
-import { render, RenderResult, waitFor, fireEvent } from '@testing-library/react';
+import {
+  render,
+  RenderResult,
+  waitFor,
+  fireEvent
+} from '@testing-library/react';
 import { act } from 'react-dom/test-utils';
 
 import * as chromeHelpers from '../../helpers/chrome';

--- a/src/components/__tests__/whitelist.test.tsx
+++ b/src/components/__tests__/whitelist.test.tsx
@@ -1,6 +1,12 @@
 /* eslint-disable import/named */
 import React from 'react';
-import { render, act, RenderResult, waitFor, fireEvent } from '@testing-library/react';
+import {
+  render,
+  act,
+  RenderResult,
+  waitFor,
+  fireEvent,
+} from '@testing-library/react';
 import * as chromeHelpers from '../../helpers/chrome';
 import {
   getWhitelist,

--- a/src/components/popup.tsx
+++ b/src/components/popup.tsx
@@ -24,6 +24,7 @@ const Popup = () => {
       try {
         result = await getActiveColor();
       } catch (e) {
+        /* eslint-disable-next-line no-console */
         console.log('Did Not Receive Color');
       }
 

--- a/src/components/whitelist.tsx
+++ b/src/components/whitelist.tsx
@@ -16,6 +16,7 @@ const WhitelistManager = () => {
       try {
         urls = await getWhitelist();
       } catch (e) {
+        /* eslint-disable-next-line no-console */
         console.log(e);
       }
 
@@ -32,6 +33,7 @@ const WhitelistManager = () => {
       try {
         removeUrlFromWhitelist(url);
       } catch (e) {
+        /* eslint-disable-next-line no-console */
         console.log(e);
       }
 
@@ -48,6 +50,7 @@ const WhitelistManager = () => {
       try {
         addUrlToWhitelist(url);
       } catch (e) {
+        /* eslint-disable-next-line no-console */
         console.log(e);
       }
 

--- a/src/content-scripts/contentscript.ts
+++ b/src/content-scripts/contentscript.ts
@@ -1,8 +1,7 @@
 const displayStyles = function displayStyles(location) {
   return new Promise((resolve) => {
     chrome.storage.sync.get("whitelist", (result) => {
-      const arr =
-        result.whitelist && result.whitelist.length ? result.whitelist : [];
+      const arr = result.whitelist && result.whitelist.length ? result.whitelist : [];
       const { origin } = location;
       const isWhitelisted = arr.filter((url) => url === origin);
 
@@ -19,8 +18,8 @@ const initializeStylesheet = function initializeStylesheet() {
   chrome.storage.sync.get("color", (results) => {
     if (results.color) {
       styleElement.sheet.insertRule(
-        "a:visited {color: " + results.color + ";}",
-        0
+        `a:visited {color: "${results.color}";}`,
+        0,
       );
       return;
     }
@@ -40,14 +39,14 @@ const setStyleSheet = function setStyleSheet(color) {
 
   if (styleSheet) {
     styleSheet.deleteRule(0);
-    styleSheet.insertRule("a:visited { color:" + color + "}", 0);
+    styleSheet.insertRule(`a:visited { color:"${color}"}`, 0);
     chrome.storage.sync.set({ color }, () => {});
   }
 };
 
-const colorListener = function colorListener(request, sender, sendResponse) {
+const colorListener = function colorListener(request) {
   // eslint-disable-line no-unused-vars
-  const color = request.color;
+  const { color } = request;
 
   if (color) {
     setStyleSheet(color);
@@ -61,4 +60,5 @@ displayStyles(window.location)
     initializeStylesheet();
     chrome.runtime.onMessage.addListener(colorListener);
   })
+  /* eslint-disable-next-line no-console */
   .catch((err) => console.log(err));

--- a/src/helpers/__tests__/chrome.test.ts
+++ b/src/helpers/__tests__/chrome.test.ts
@@ -1,4 +1,9 @@
-import { getActiveColor, getCurrentUrl, saveActiveColor, reloadCurrentTab } from '../chrome';
+import {
+  getActiveColor,
+  getCurrentUrl,
+  saveActiveColor,
+  reloadCurrentTab,
+} from '../chrome';
 
 describe('chrome helpers >', () => {
   afterEach(() => {
@@ -44,7 +49,7 @@ describe('chrome helpers >', () => {
     expect(chrome.tabs.sendMessage).toHaveBeenCalledWith(
       undefined,
       { color },
-      expect.any(Function)
+      expect.any(Function),
     );
   });
 


### PR DESCRIPTION
I noticed we had a few linting errors and warnings, so this PR aims to clean them up.

<img width="623" alt="Screen Shot 2020-05-17 at 9 17 59 AM" src="https://user-images.githubusercontent.com/986567/82150965-a3ef5280-981f-11ea-99ff-e6e2fe193a82.png">

At this point, all but two errors have been resolved. The following errors remain:

```
/color-links/src/helpers/__mocks__/chrome.ts
  0:0  error  Parsing error: "parserOptions.project" has been set for @typescript-eslint/parser.
The file does not match your project config: src/helpers/__mocks__/chrome.ts.
The file must be included in at least one of the projects provided

/color-links/src/helpers/__mocks__/whitelisting.ts
  0:0  error  Parsing error: "parserOptions.project" has been set for @typescript-eslint/parser.
The file does not match your project config: src/helpers/__mocks__/whitelisting.ts.
The file must be included in at least one of the projects provided
```

@therynamo let me know what your thoughts are on these two errors. 💭 